### PR TITLE
feat: add target lock and model refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,13 @@ Follow these sparkly steps to get your TensorRT ready for action! 🛠️✨
 
 If you've followed these steps, you should be all set with TensorRT! ⚙️🚀
 
-Dont forget to select your model in the menu!
+Place your `.pt`, `.onnx` or `.engine` model anywhere under the project root
+or inside the `models` directory—the configuration menu scans these paths
+recursively and enables the **Run Softaim** button only when a valid model is
+available. Use the **Refresh Models** button if you add files while the menu is
+open, and don't forget to pick a model before running!
+
+The aimbot now maintains a lock on the current detection, avoiding rapid
+switching when multiple targets are present. Adjust the `targetLockRadius`
+value in `config.py` to control how far a target can move before a new one is
+selected.

--- a/config.py
+++ b/config.py
@@ -32,3 +32,4 @@ overlayColor = '#FF0000'
 toggleAimbot = True
 activationKey = 'VK_MENU'
 showStatus = True
+targetLockRadius = 50


### PR DESCRIPTION
## Summary
- search recursively for model files and create `models` folder automatically
- add refresh button and disable run when no valid model is found
- document model discovery improvements
- track previous detection and keep aim on it while it remains within `targetLockRadius`
- document target locking in README

## Testing
- `python -m py_compile config.py main_tensorrt.py`


------
https://chatgpt.com/codex/tasks/task_e_689d8eb389748324a8e6a53fbd99ec1c