### PR TITLE
Add adjustable mouse smoothing

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,3 +33,4 @@ toggleAimbot = True
 activationKey = 'VK_MENU'
 showStatus = True
 targetLockRadius = 50
+smoothingFactor = 0.5

--- a/main_tensorrt.py
+++ b/main_tensorrt.py
@@ -8,7 +8,7 @@ import pandas as pd
 from utils.general import (cv2, non_max_suppression, xyxy2xywh)
 from models.common import DetectMultiBackend
 import cupy as cp
-from config import jitterStrength, showStatus, activationKey, toggleAimbot, showTracers, showBoxes, overlayColor, showFOVCircle, screenShotHeight, screenShotWidth, aaMovementAmp, aaTriggerBotKey, aaMovementAmpHipfire, realtimeOverlay, jitterValueX, jitterValueY, aaPauseKey, useMask, maskHeight, maskWidth, aaQuitKey, confidence, cpsDisplay, visuals, centerOfScreen, fovCircleSize, BodyPart, RandomBodyPart, targetLockRadius
+from config import jitterStrength, showStatus, activationKey, toggleAimbot, showTracers, showBoxes, overlayColor, showFOVCircle, screenShotHeight, screenShotWidth, aaMovementAmp, aaTriggerBotKey, aaMovementAmpHipfire, realtimeOverlay, jitterValueX, jitterValueY, aaPauseKey, useMask, maskHeight, maskWidth, aaQuitKey, confidence, cpsDisplay, visuals, centerOfScreen, fovCircleSize, BodyPart, RandomBodyPart, targetLockRadius, smoothingFactor
 import gameSelection
 import sys
 import random
@@ -35,6 +35,15 @@ def generate_jitter(scale=jitterStrength):
 
 def is_right_mouse_button_pressed():
     return win32api.GetKeyState(win32con.VK_RBUTTON) < 0
+
+def apply_smoothing(move, amp):
+    """Interpolate cursor movement using the configured smoothing factor."""
+    curr_x, curr_y = win32api.GetCursorPos()
+    target_x = curr_x + int(move[0] * amp)
+    target_y = curr_y + int(move[1] * amp)
+    smoothed_x = curr_x + int((target_x - curr_x) * smoothingFactor)
+    smoothed_y = curr_y + int((target_y - curr_y) * smoothingFactor)
+    win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, smoothed_x - curr_x, smoothed_y - curr_y, 0, 0)
 
 def calculate_offsets(screenShotWidth, screenShotHeight):
     if screenShotWidth == 320 and screenShotHeight == 320:
@@ -251,16 +260,12 @@ def main():
                         mouseMove[0] = int(mouseMove[0] + jitter_x)
                         mouseMove[1] = int(mouseMove[1] + jitter_y)
 
-                        # Move mouse
+                        # Move mouse with smoothing
                         if is_right_mouse_button_pressed():
-                            win32api.mouse_event(win32con.MOUSEEVENTF_MOVE,
-                            int(mouseMove[0] * aaMovementAmp),
-                            int(mouseMove[1] * aaMovementAmp), 0, 0)
+                            apply_smoothing(mouseMove, aaMovementAmp)
                         else:
                             # If hipfire then hipfire modifier
-                            win32api.mouse_event(win32con.MOUSEEVENTF_MOVE,
-                            int(mouseMove[0] * aaMovementAmpHipfire),
-                            int(mouseMove[1] * aaMovementAmpHipfire), 0, 0)
+                            apply_smoothing(mouseMove, aaMovementAmpHipfire)
                          
                     
 

--- a/menu.py
+++ b/menu.py
@@ -131,6 +131,7 @@ class App(customtkinter.CTk):
                 config_file.write(f"gameName = '{game_name_entry.get()}'\n")
                 config_file.write(f"aaMovementAmp = {float(aa_movement_amp_entry.get())}\n")
                 config_file.write(f"aaMovementAmpHipfire = {float(aa_movement_amp_hipfire_entry.get())}\n")
+                config_file.write(f"smoothingFactor = {float(smoothing_factor_entry.get())}\n")
                 config_file.write(f"confidence = {float(confidence_entry.get())}\n")
                 config_file.write(f"fovCircleSize = {fov_circle_size_entry.get()}\n")
                 config_file.write(f"aaQuitKey = '{aa_quit_key_entry.get()}'\n")
@@ -258,6 +259,7 @@ class App(customtkinter.CTk):
         jitterStrength_entry = create_setting_widget(self.third_frame, "Jitter Strength", 7, 0)
         jitterX_value_box = create_setting_widget(self.third_frame, "Jitter X Range", 8, 0)
         jitterY_value_box = create_setting_widget(self.third_frame, "Jitter Y Range", 9, 0)
+        smoothing_factor_entry = create_setting_widget(self.third_frame, "Smoothing Factor", 10, 0)
         auto_game_detection_switch = create_setting_widget(self.third_frame, "Automatic Game Detection", 1, 2, widget_type=customtkinter.CTkSwitch, text="")
         random_body_part_switch = create_setting_widget(self.third_frame, "Randomized Body Part", 2, 2, widget_type=customtkinter.CTkSwitch, text="")
         triggerBot_switch = create_setting_widget(self.third_frame, "Trigger Bot", 3, 2, widget_type=customtkinter.CTkSwitch, text="")
@@ -333,6 +335,7 @@ class App(customtkinter.CTk):
         set_initial_values(triggerbot_actdistance_entry, config.triggerbot_actdistance)
         set_initial_values(overlayColor_entry, config.overlayColor)
         set_initial_values(jitterStrength_entry, config.jitterStrength)
+        set_initial_values(smoothing_factor_entry, config.smoothingFactor)
 
         set_switch(use_mask_switch, config.useMask)
         set_switch(auto_game_detection_switch, config.autoGameDetection)


### PR DESCRIPTION
## Summary
- add `smoothingFactor` setting with default value and menu option
- smooth cursor movement using interpolation before `win32api.mouse_event`

## Testing
- `python -m py_compile config.py menu.py main_tensorrt.py`


------
https://chatgpt.com/codex/tasks/task_e_689da19e3cac83249db064e916d514e2